### PR TITLE
Api chart

### DIFF
--- a/charts/mobile-api/Chart.yaml
+++ b/charts/mobile-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mobile-api
 description: Helm chart for mobile-api app
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: "0.0.31"
 keywords:
 - mobile-api

--- a/charts/mobile-api/values.yaml
+++ b/charts/mobile-api/values.yaml
@@ -42,7 +42,7 @@ containerPort: 80
 healthCheck: ""
 
 service:
-  type: ClusterIP
+  type: NodePort
   port: 80
 
 ingress:


### PR DESCRIPTION
- bump chart version for mobile-api
- mobile-api needs NodePort so it can be reached by the load balancer